### PR TITLE
Support for finding regions overlapped by two different IntervalTrees

### DIFF
--- a/intervaltree/intervaltree.py
+++ b/intervaltree/intervaltree.py
@@ -437,6 +437,17 @@ class IntervalTree(collections.MutableSet):
             if iv not in other:
                 self.remove(iv)
 
+    def overlap_intervals(self,other):
+        """
+        Returns a new IntervalTree consisting of intervals representing the
+        regions overlapped by at least one interval in both of self and other.
+        """
+        splits = (self | other)
+        splits.split_overlaps()
+        self_int_other =  IntervalTree(filter(lambda r: self.overlaps(r) and other.overlaps(r), splits))
+        self_int_other.merge_overlaps()
+        return self_int_other
+
     def symmetric_difference(self, other):
         """
         Return a tree with elements only in self or other but not


### PR DESCRIPTION
This change adds a function for finding the common regions between two interval trees. That is, the intervals in the result are the ranges where at least one interval in both trees overlap each other.
