### PR TITLE
Complexity of IntervalTree.{begin,end} is O(1), not O(n).

### DIFF
--- a/intervaltree/intervaltree.py
+++ b/intervaltree/intervaltree.py
@@ -818,7 +818,7 @@ class IntervalTree(collections.MutableSet):
         """
         Returns the lower bound of the first interval in the tree.
         
-        Completes in O(n) time.
+        Completes in O(1) time.
         """
         if not self.boundary_table:
             return 0
@@ -828,7 +828,7 @@ class IntervalTree(collections.MutableSet):
         """
         Returns the upper bound of the last interval in the tree.
         
-        Completes in O(n) time.
+        Completes in O(1) time.
         """
         if not self.boundary_table:
             return 0


### PR DESCRIPTION
They call `self.boundary_table.iloc[0]` (resp. `[-1]`), and `self.boundary_table` is a SortedDict.
`SortedDict.iloc` is an instance of `_IlocWrapper`, whose `__getitem__` only does: `return self._dict._list[index]`
`_dict` is the SortedDict instance, and `_dict._list` is an instance of `SortedList`.
Finally, `SortedList.__item__` has special cases to perform in O(1) when the index is 0 or -1.

References:
- https://github.com/grantjenks/sorted_containers/blob/ccec8d4/sortedcontainers/sorteddict.py#L34-L40
- https://github.com/grantjenks/sorted_containers/blob/b62fe6a/sortedcontainers/sortedlist.py#L599-L602
