### PR TITLE
Fixed bug in remove

### DIFF
--- a/intervaltree/node.py
+++ b/intervaltree/node.py
@@ -393,26 +393,26 @@ class Node(object):
         else:
             #print('Pop descent to {}'.format(self[1].x_center))
             (greatest_child, self[1]) = self[1].pop_greatest_child()
-            self.refresh_balance()
-            new_self = self.rotate()
 
             # Move any overlaps into greatest_child
-            for iv in set(new_self.s_center):
+            for iv in set(self.s_center):
                 if iv.contains_point(greatest_child.x_center):
-                    new_self.s_center.remove(iv)
+                    self.s_center.remove(iv)
                     greatest_child.add(iv)
 
             #print('Pop Returning child   = {}'.format(
             #    greatest_child.print_structure(tostring=True)
             #    ))
-            if new_self.s_center:
+            if self.s_center:
                 #print('and returning newnode = {}'.format(
                 #    new_self.print_structure(tostring=True)
                 #    ))
                 #new_self.verify()
+                self.refresh_balance()
+                new_self = self.rotate()
                 return greatest_child, new_self
             else:
-                new_self = new_self.prune()
+                new_self = self.prune()
                 #print('and returning prune = {}'.format(
                 #    new_self.print_structure(tostring=True)
                 #    ))


### PR DESCRIPTION
The bug occurs when replacing a removed node. If `child` consumes all the nodes in `s_center`, the node is completely removed from the tree which allows its parent to become in balanced. Re-balancing will happen in lines 399-400 and cause the parent to be rotated down to be the right child of its current left child. The problem here is that if the parent contains any overlapping intervals with `child.x_center`, these intervals will not be added to child, since the check for overlaps in lines 403-405 will look at the new parent (i.e. the left child of the old parent). Thus, the invariant that no node overlaps the `x_center` of any of its ancestors is broken.