### PR TITLE
Fix issue #72 - Check for overlapping child nodes on deletion

### DIFF
--- a/intervaltree/node.py
+++ b/intervaltree/node.py
@@ -376,7 +376,8 @@ class Node(object):
             self.s_center -= child.s_center
 
             # Move any overlaps into child
-            for iv in set(self.s_center):
+            for iv in set(self.s_center
+                    | (self[0].s_center if self[0] else set())):
                 if iv.contains_point(child.x_center):
                     self.s_center.discard(iv)
                     child.add(iv)

--- a/intervaltree/node.py
+++ b/intervaltree/node.py
@@ -399,8 +399,8 @@ class Node(object):
             # Move any overlaps into greatest_child
             # This include overlapping child intervals or overlap intervals
             for iv in set(new_self.s_center
-                        | (new_self[0].s_center if new_self[0] else set())
-                        | (new_self[1].s_center if new_self[1] else set()):
+                    | (new_self[0].s_center if new_self[0] else set())
+                    | (new_self[1].s_center if new_self[1] else set())):
                 if iv.contains_point(greatest_child.x_center):
                     # use discard instead of remove so no error is thrown
                     # if it' not an from the center

--- a/intervaltree/node.py
+++ b/intervaltree/node.py
@@ -375,6 +375,12 @@ class Node(object):
             child = Node(new_x_center, get_new_s_center())
             self.s_center -= child.s_center
 
+            # Move any overlaps into child
+            for iv in set(self.s_center):
+                if iv.contains_point(child.x_center):
+                    self.s_center.discard(iv)
+                    child.add(iv)
+
             #print('Pop hit! Returning child   = {}'.format(
             #    child.print_structure(tostring=True)
             #    ))

--- a/intervaltree/node.py
+++ b/intervaltree/node.py
@@ -397,9 +397,14 @@ class Node(object):
             new_self = self.rotate()
 
             # Move any overlaps into greatest_child
-            for iv in set(new_self.s_center):
+            # This include overlapping child intervals or overlap intervals
+            for iv in set(new_self.s_center
+                        | (new_self[0].s_center if new_self[0] else set())
+                        | (new_self[1].s_center if new_self[1] else set()):
                 if iv.contains_point(greatest_child.x_center):
-                    new_self.s_center.remove(iv)
+                    # use discard instead of remove so no error is thrown
+                    # if it' not an from the center
+                    new_self.s_center.discard(iv)
                     greatest_child.add(iv)
 
             #print('Pop Returning child   = {}'.format(


### PR DESCRIPTION
This pull request addresses #72 Which causes a key error due to improper balancing on node removal.