### PR TITLE
Sort only once intervals during initialization

### DIFF
--- a/intervaltree/node.py
+++ b/intervaltree/node.py
@@ -63,8 +63,17 @@ class Node(object):
         """
         if not intervals:
             return None
+        return Node.from_sorted_intervals(sorted(intervals))
+
+    @classmethod
+    def from_sorted_intervals(cls, intervals):
+        """
+        :rtype : Node
+        """
+        if not intervals:
+            return None
         node = Node()
-        node = node.init_from_sorted(sorted(intervals))
+        node = node.init_from_sorted(intervals)
         return node
 
     def init_from_sorted(self, intervals):
@@ -82,8 +91,8 @@ class Node(object):
                 s_right.append(k)
             else:
                 self.s_center.add(k)
-        self.left_node = Node.from_intervals(s_left)
-        self.right_node = Node.from_intervals(s_right)
+        self.left_node = Node.from_sorted_intervals(s_left)
+        self.right_node = Node.from_sorted_intervals(s_right)
         return self.rotate()
 
     def center_hit(self, interval):


### PR DESCRIPTION
The `Node` initialization from a list of intervals is currently sorting the intervals, spliiting them between the left and right and nodes, and then recursively doing the same thing for both nodes.
However, the itinial list order is preserved when building the left and right nodes' interval lists, so it is not necessary to sort intervals recursively.

This PR ensures that intervals are only sorted once.

I've evaluated the performance gain using the following code:
```py
from intervaltree import IntervalTree, Interval
NB_INTERVALS = 1000
intervals = [Interval(i, i + 100) for i in range(NB_INTERVALS)]
%timeit IntervalTree(intervals)
```
Results:

| Number of intervals | 1000 | 10000 | 100000 | 1000000 |
| ------------- |:-------------:| -----:| -----:| -----:|
| Old version | 12ms | 150ms | 2.1s | 28s |
| New version | 10ms | 130ms | 1.7s | 21s |
| Speed Improvement | 17% | 13% | 19% | 25% |

The gain is quite significant, and increases with the number of intervals.

Existing tests still pass.