### PR TITLE
Add intersection, union, and difference methods

### DIFF
--- a/intervaltree/interval.py
+++ b/intervaltree/interval.py
@@ -84,6 +84,66 @@ class Interval(namedtuple('IntervalBase', ['begin', 'end', 'data'])):
         :rtype: bool
         """
         return self.begin <= p < self.end
+
+    def intersection(self, other):
+        """
+        The intersection/overlap between this interval and another interval.
+        Returns None if not overlapping.
+        :param other: an interval
+        :return: An interval representing the overlap between both intervals
+        :rtype: Optional[Interval]
+        """
+        if self.is_null() or other.is_null():
+            raise ValueError('Cannot intersect null intervals')
+        if not self.overlaps(other):
+            return None
+        return Interval(max(self.begin, other.begin), min(self.end, other.end), self.data)
+
+    def union(self, other):
+        """
+        The union/combination between this interval and another interval
+        Returns None if not overlapping.
+        :param other: an interval
+        :return: An interval representing the combination between both intervals
+        :rtype: Optional[Interval]
+        """
+        if self.is_null() or other.is_null():
+            raise ValueError('Cannot unionize null intervals')
+        if not self.overlaps(other):
+            return None
+        return Interval(min(self.begin, other.begin), max(self.end, other.end), self.data)
+
+    def difference(self, other):
+        """
+        Returns 0 to 2 intervals that do not have any area in common with the other interval.
+        Returns an empty array if not overlapping or if other envelops this interval.
+        :param other: an interval
+        :return: An interval representing the negative space between both intervals
+        :rtype: List[Interval]
+        """
+        set().difference()
+        if self.is_null() or other.is_null():
+            raise ValueError('Cannot subtract null itervals from each other')
+        if not self.overlaps(other):
+            return []
+        diff = []
+        if other.begin > self.begin:
+            diff.append(Interval(self.begin, other.begin, self.data))
+        if self.end > other.end:
+            diff.append(Interval(other.end, self.end, self.data))
+        return diff
+
+    def __and__(self, other):
+        """return self.intersection"""
+        return self.intersection(other)
+
+    def __or__(self, other):
+        """return self.union()"""
+        return self.union(other)
+
+    def __sub__(self, other):
+        """return self.difference()"""
+        return self.difference(other)
     
     def range_matches(self, other):
         """

--- a/test/interval_methods/binary_test.py
+++ b/test/interval_methods/binary_test.py
@@ -110,6 +110,58 @@ def test_distance_to_point():
     assert iv0.distance_to(15) == 5
 
 
+def test_interval_intersection():
+    assert iv0.intersection(iv0) == Interval(0, 10)
+    assert not iv0.intersection(iv1)
+    assert not iv0.intersection(iv2)
+
+    assert iv0.intersection(iv3) == Interval(0, 5)
+    assert iv0.intersection(iv4) == Interval(0, 10)
+    assert iv0.intersection(iv5) == Interval(0, 10)
+    assert iv0.intersection(iv6) == Interval(0, 10)
+    assert iv0.intersection(iv7) == Interval(5, 10)
+    assert not iv0.intersection(iv8)
+    assert not iv0.intersection(iv9)
+
+
+def test_interval_union():
+    assert iv0.union(iv0) == Interval(0, 10)
+    assert not iv0.union(iv1)
+    assert not iv0.union(iv2)
+
+    assert iv0.union(iv3) == Interval(-10, 10)
+    assert iv0.union(iv4) == Interval(-10, 10)
+    assert iv0.union(iv5) == Interval(-10, 20)
+    assert iv0.union(iv6) == Interval(0, 20)
+    assert iv0.union(iv7) == Interval(0, 20)
+    assert not iv0.union(iv8)
+    assert not iv0.union(iv9)
+
+
+def test_interval_difference():
+    assert not iv0.difference(iv0)
+    assert not iv0.difference(iv1)
+    assert not iv0.difference(iv2)
+    assert iv0.difference(iv3) == [Interval(5, 10)]
+    assert not iv0.difference(iv4)
+    assert not iv0.difference(iv5)
+    assert not iv0.difference(iv6)
+    assert iv0.difference(iv7) == [Interval(0, 5)]
+    assert not iv0.difference(iv8)
+    assert not iv0.difference(iv9)
+
+    assert iv5.difference(iv0) == [Interval(-10, 0), Interval(10, 20)]
+    assert iv5.difference(iv1) == [Interval(-5, 20)]
+    assert iv5.difference(iv2) == [Interval(0, 20)]
+    assert iv5.difference(iv3) == [Interval(5, 20)]
+    assert iv5.difference(iv4) == [Interval(10, 20)]
+    assert not iv5.difference(iv5)
+    assert iv5.difference(iv6) == [Interval(-10, 0)]
+    assert iv5.difference(iv7) == [Interval(-10, 5)]
+    assert iv5.difference(iv8) == [Interval(-10, 10)]
+    assert iv5.difference(iv9) == [Interval(-10, 15)]
+
+
 if __name__ == "__main__":
     import pytest
     pytest.main([__file__, '-v'])


### PR DESCRIPTION
3 interval functions that you find in the `set()` builtin class. Intersection, difference, and union.

I would rather show than tell.
```
A:   ==========
B:      =====
A&B:    =====
A|B: ==========
A-B: ===     ==
B-A:
```

In code that means.
```
a = Interval(0, 10)
b = Interval (3, 7)
assert a & b == a.intersection(b) == Interval(3, 7)
assert a | b == a.union(b) == Interval(0, 10)
assert a - b == a.difference(b) == [Interval(0, 3), nterval(7, 10)]
assert b - a == b.difference(a) == []
```

In the future, intervaltree can have better functionality in terms of slicing, intersecting, and unioning. I thought that's what the intersection function did, but after looking at the implementation I misunderstood. This PR is the first step that would help get there.

For example, here are some things we can add in the future after this PR is merged.
- IntervalTree.interval_intersection(other_tree)
- IntervalTree.interval_intersection_update(other_tree)
- IntervalTree.interval_union(other_tree)
- IntervalTree.interval_union_update(other_tree)
- IntervalTree.interval_difference(other_tree)
- IntervalTree.interval_difference_update(other_tree) [kinda like `chop(other_iv)` in a loop]