### PR TITLE
Include test files in PyPI tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include README.md CHANGELOG.md LICENSE.txt
+recursive-include test *


### PR DESCRIPTION
For OpenBSD ports, it is quite useful to have regression tests include in the source tarball so we can easily make sure updates don't hurt the functionality of ports (either the one in question, or ports that depend on it). This change includes the test files.