### PR TITLE
Add merge_neighbors() restructuring method

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Features
     * `split_overlaps()`      (slice at all interval boundaries, optionally modifying the data field)
     * `merge_overlaps()` (joins overlapping intervals into a single interval, optionally merging the data fields)
     * `merge_equals()` (joins intervals with matching ranges into a single interval, optionally merging the data fields)
+    * `merge_neighbors()` (joins adjacent intervals into a single interval if the distance between their range terminals is less than or equal to a given distance. Optionally merges overlapping intervals. Can also merge the data fields.)
 
 * Copying and typecasting
     * `IntervalTree(tree)`    (`Interval` objects are same as those in tree)

--- a/intervaltree/intervaltree.py
+++ b/intervaltree/intervaltree.py
@@ -668,7 +668,7 @@ class IntervalTree(MutableSet):
         will not be merged. If strict is False, intervals are merged
         even if they are only end-to-end adjacent.
 
-        Completes in O(n*logn).
+        Completes in O(n*logn) time.
         """
         if not self:
             return
@@ -729,7 +729,7 @@ class IntervalTree(MutableSet):
         data_initiazer created with
             copy.copy(data_initializer).
 
-        Completes in O(n*logn).
+        Completes in O(n*logn) time.
         """
         if not self:
             return
@@ -754,6 +754,66 @@ class IntervalTree(MutableSet):
             if merged:  # series already begun
                 lower = merged[-1]
                 if higher.range_matches(lower):  # should merge
+                    upper_bound = max(lower.end, higher.end)
+                    if data_reducer is not None:
+                        current_reduced[0] = data_reducer(current_reduced[0], higher.data)
+                    else:  # annihilate the data, since we don't know how to merge it
+                        current_reduced[0] = None
+                    merged[-1] = Interval(lower.begin, upper_bound, current_reduced[0])
+                else:
+                    new_series()
+            else:  # not merged; is first of Intervals to merge
+                new_series()
+
+        self.__init__(merged)
+
+    def merge_neighbors(self, data_reducer=None, data_initializer=None, distance=1):
+        """
+        Finds all adjacent intervals with ranges less than or equal to the given
+        distance and merges them into a single interval. If provided, uses 
+        data_reducer and data_initializer with similar semantics to Python's 
+        built-in reduce(reducer_func[, initializer]), as follows:
+
+        If data_reducer is set to a function, combines the data
+        fields of the Intervals with
+            current_reduced_data = data_reducer(current_reduced_data, new_data)
+        If data_reducer is None, the merged Interval's data
+        field will be set to None, ignoring all the data fields
+        of the merged Intervals.
+
+        On encountering the first Interval to merge, if
+        data_initializer is None (default), uses the first
+        Interval's data field as the first value for
+        current_reduced_data. If data_initializer is not None,
+        current_reduced_data is set to a shallow copy of
+        data_initiazer created with
+            copy.copy(data_initializer).
+
+        Completes in O(n*logn) time.
+        """
+        if not self:
+            return
+
+        sorted_intervals = sorted(self.all_intervals)  # get sorted intervals
+        merged = []
+        # use mutable object to allow new_series() to modify it
+        current_reduced = [None]
+        higher = None  # iterating variable, which new_series() needs access to
+
+        def new_series():
+            if data_initializer is None:
+                current_reduced[0] = higher.data
+                merged.append(higher)
+                return
+            else:  # data_initializer is not None
+                current_reduced[0] = copy(data_initializer)
+                current_reduced[0] = data_reducer(current_reduced[0], higher.data)
+                merged.append(Interval(higher.begin, higher.end, current_reduced[0]))
+
+        for higher in sorted_intervals:
+            if merged:  # series already begun
+                lower = merged[-1]
+                if (higher.begin - lower.end <= distance):  # should merge
                     upper_bound = max(lower.end, higher.end)
                     if data_reducer is not None:
                         current_reduced[0] = data_reducer(current_reduced[0], higher.data)


### PR DESCRIPTION
Hello @chaimleib,

I've found this library to be quite useful and a pleasure to use. Many thanks from me to you (and your co-contributors)!

I have a use case in which I want to merge "close enough" intervals. The changes I propose add a `merge_neighbors(...)` method quite similar to `merge_overlaps(...)`.

I do not expect you to immediately merge these changes. Rather, I anticipate some feedback and will try to comply.

Here are a few questions, with the first being of primary importance, else the rest are moot!

1. Do you see such a restructuring strategy as appropriate for inclusion in this library?
2. I wasn't sure whether I should ~~allow~~ prevent overlap merging through `strict=True` or `strict=False`. I went with the former, since I understand it to be a more conservative merging operation. Do you agree? 
_edit: false --> merge overlaps; true --> keep overlaps_
3. Do you have naming critiques? `neighbors` seemed descriptive enough, but perhaps there is a more appropriate domain-specific name I am unaware of.
4. The tests I added are not exhaustive; can you think of other edge cases?
5. With my addition of a third `merge_*` method, the code is now wetter (as in, not [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself)) -- we see `new_series()` as an example of _write everything thrice_. Would you be open to some sort of `common.py` module, or would you like to keep everything self-contained?

Addenda:
- this PR adds section-marking comments to the test file
- this PR standardizes some comments
- this PR adds a `README.md` entry