### PR TITLE
Add remove_data method

### DIFF
--- a/intervaltree/intervaltree.py
+++ b/intervaltree/intervaltree.py
@@ -469,9 +469,9 @@ class IntervalTree(MutableSet):
 
     def remove_data(self, data, points=None):
         """
-        Removes all intervals containing the given data. Providing a set of points contained by the
-        intervals will speed up the operation considerably, but will only succeed if all the
-        intervals with the given data also contain the points.
+        Removes all intervals containing the given data. If a set of points is provided,
+        only intervals containing the points AND containing the given data will be removed.
+        Providing a set of points speeds up the operation considerably.
         """
         if data is None:
             raise ValueError("IntervalTree: No data submitted.")

--- a/intervaltree/intervaltree.py
+++ b/intervaltree/intervaltree.py
@@ -467,6 +467,28 @@ class IntervalTree(MutableSet):
                 other.remove(iv)
         self.update(other)
 
+    def remove_data(self, data, points=None):
+        """
+        Removes all intervals containing the given data. Providing a set of points contained by the
+        intervals will speed up the operation considerably, but will only succeed if all the
+        intervals with the given data also contain the points.
+        """
+        if data is None:
+            raise ValueError("IntervalTree: No data submitted.")
+
+        if points is not None:
+            root = self.top_node
+            ivs = set()
+            for point in points:
+                ivs |= root.search_point(point, set())
+            ivs_with_data = [iv for iv in ivs if iv.data == data]
+            for iv in ivs_with_data:
+                self.discard(iv)
+        else:
+            ivs_without_data = [iv for iv in self.items() if iv.data != data]
+            self.clear()
+            self.__init__(ivs_without_data)
+
     def remove_overlap(self, begin, end=None):
         """
         Removes all intervals overlapping the given point or range.


### PR DESCRIPTION
Hello @chaimleib,

Firstly, much thanks to you and co-contributors for building this excellent library.

I have a use case in which I want to delete intervals which are tagged with a certain data. The changes I propose add a remove_data(...) method which removes all intervals containing the data. If the optional set of points `points` argument is filled, only intervals containing these points and also the given data will be removed. Providing `points` lends a considerable speedup, as the only other way to remove points with certain data, as far as I can see, is to rebuild the entire tree.

Please let me know your thoughts.