### PR TITLE
Add parallel-is-installed to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,10 +88,14 @@ sdist-upload: distclean deps-dev
 		$(TWINE) upload dist/*; \
 	fi
 
-deps-dev: pyenv-install-versions
+deps-dev: pyenv-install-versions parallel-is-installed
 
 # Uploads to test server, unless the release target was run too
 upload: test clean sdist-upload
+
+# The testall.sh script uses parallel
+parallel-is-installed:
+	parallel --version &>/dev/null || (echo "ERROR: parallel not installed" && false)
 
 pyenv-is-installed:
 	pyenv --version &>/dev/null || (echo "ERROR: pyenv not installed" && false)
@@ -137,6 +141,7 @@ env:
 	install-develop \
 	pyenv-install-versions \
 	pyenv-is-installed \
+	parallel-is-installed \
 	uninstall \
 	register \
 	release \


### PR DESCRIPTION
Arch Linux appears to not come with parallel installed by default, so I assume a few other distributions probably leave it off as well?

I added it to the `deps-dev` group.

I have never really worked with Makefiles before. Feel free to close if you think that this is a small enough dependency that we don't need an explicit warning!