### PR TITLE
Update Python Versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,14 @@
 language: python
 matrix:
   include:
-    - python: 2.7
-    - python: 3.5
-    - python: 3.6
     - python: 3.7
     - python: 3.8
+    - python: 3.9
+    - python: 3.10
+    - python: 3.11
       dist: xenial
       sudo: true
-    - python: 3.9-dev
+    - python: 3.12-dev
       env: FAILOK=y
       dist: xenial
       sudo: true

--- a/HACKING.md
+++ b/HACKING.md
@@ -9,7 +9,7 @@ This is a developer's guide to modifying and maintaining `intervaltree`.
 
 * On Linux, you will need `apt-get`.
 
-On all systems, Python 2.6, 2.7, 3.2, 3.3, 3.4 and 3.5 are needed to run the complete test suite. 
+On all systems, Python 3.7 thru 3.12 are needed to run the complete test suite.
 
 ### Single version of Python
 
@@ -87,7 +87,7 @@ The two commands above run all the available tests on all versions of Python sup
 
 The first time you run `make`, you may be asked for your password. This is in order to install `pandoc`, a tool used for processing the README file.
 
-Running all tests requires that you have all the supported versions of Python installed. These are 2.6, 2.7, 3.2, 3.3, 3.4 and 3.5. Try to use your package manager to install them if possible. Otherwise, go to [python.org/downloads][] and install them manually.
+Running all tests requires that you have all the supported versions of Python installed. These are 3.7 thru 3.12. Try to use your package manager to install them if possible. Otherwise, go to [python.org/downloads][] and install them manually.
 
 #### Single version of Python
 

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,9 @@ TEMPS=$(shell                                                   \
 		-o \( -type d -name '__pycache__' \)                    \
 )
 
-PYTHONS:=2.7.18 3.5.9 3.6.11 3.7.8 3.8.5
+# See https://devguide.python.org/versions
+# Use every version that is not end-of-life.
+PYTHONS:=3.7.16 3.8.16 3.9.16 3.10.9 3.11.1 3.12.0a4
 PYTHON_MAJORS:=$(shell        \
 	echo "$(PYTHONS)" |         \
 	tr ' ' '\n' | cut -d. -f1 | \

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 intervaltree
 ============
 
-A mutable, self-balancing interval tree for Python 2 and 3. Queries may be by point, by range overlap, or by range envelopment.
+A mutable, self-balancing interval tree for Python. Queries may be by point, by range overlap, or by range envelopment.
 
 This library was designed to allow tagging text and time intervals, where the intervals include the lower bound but not the upper bound.
 
@@ -26,7 +26,7 @@ pip install intervaltree
 Features
 --------
 
-* Supports Python 2.7 and Python 3.5+ (Tested under 2.7, and 3.5 thru 3.8)
+* Supports Python 3.7+ (Tested under 3.7 thru 3.12)
 * Initializing
     * blank `tree = IntervalTree()`
     * from an iterable of `Interval` objects (`tree = IntervalTree(intervals)`)

--- a/intervaltree/__init__.py
+++ b/intervaltree/__init__.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 """
-intervaltree: A mutable, self-balancing interval tree for Python 2 and 3.
+intervaltree: A mutable, self-balancing interval tree for Python.
 Queries may be by point, by range overlap, or by range envelopment.
 
 Root package.

--- a/intervaltree/interval.py
+++ b/intervaltree/interval.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 """
-intervaltree: A mutable, self-balancing interval tree for Python 2 and 3.
+intervaltree: A mutable, self-balancing interval tree for Python.
 Queries may be by point, by range overlap, or by range envelopment.
 
 Interval class

--- a/intervaltree/intervaltree.py
+++ b/intervaltree/intervaltree.py
@@ -26,18 +26,9 @@ from .interval import Interval
 from .node import Node
 from numbers import Number
 from sortedcontainers import SortedDict
+from collections.abc import MutableSet
 from copy import copy
 from warnings import warn
-
-try:
-    from collections.abc import MutableSet  # Python 3?
-except ImportError:
-    from collections import MutableSet
-
-try:
-    xrange  # Python 2?
-except NameError:  # pragma: no cover
-    xrange = range
 
 
 # noinspection PyBroadException
@@ -900,7 +891,7 @@ class IntervalTree(MutableSet):
         bound_end = boundary_table.bisect_left(end)  # up to, but not including end
         result.update(root.search_overlap(
             # slice notation is slightly slower
-            boundary_table.keys()[index] for index in xrange(bound_begin, bound_end)
+            boundary_table.keys()[index] for index in range(bound_begin, bound_end)
         ))
 
         # TODO: improve envelop() to use node info instead of less-efficient filtering
@@ -934,7 +925,7 @@ class IntervalTree(MutableSet):
         bound_end = boundary_table.bisect_left(end)  # up to, but not including end
         result.update(root.search_overlap(
             # slice notation is slightly slower
-            boundary_table.keys()[index] for index in xrange(bound_begin, bound_end)
+            boundary_table.keys()[index] for index in range(bound_begin, bound_end)
         ))
         return result
 

--- a/intervaltree/intervaltree.py
+++ b/intervaltree/intervaltree.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 """
-intervaltree: A mutable, self-balancing interval tree for Python 2 and 3.
+intervaltree: A mutable, self-balancing interval tree for Python.
 Queries may be by point, by range overlap, or by range envelopment.
 
 Core logic.

--- a/intervaltree/node.py
+++ b/intervaltree/node.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 """
-intervaltree: A mutable, self-balancing interval tree for Python 2 and 3.
+intervaltree: A mutable, self-balancing interval tree for Python.
 Queries may be by point, by range overlap, or by range envelopment.
 
 Core logic: internal tree nodes.

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 """
-intervaltree: A mutable, self-balancing interval tree for Python 2 and 3.
+intervaltree: A mutable, self-balancing interval tree for Python.
 Queries may be by point, by range overlap, or by range envelopment.
 
 Distribution logic
@@ -81,7 +81,7 @@ setup(
     name='intervaltree',
     version=vinfo['version'],
     install_requires=['sortedcontainers >= 2.0, < 3.0'],
-    description='Editable interval tree data structure for Python 2 and 3',
+    description='Editable interval tree data structure for Python',
     long_description=long_description,
     long_description_content_type='text/markdown',
     classifiers=[  # Get strings from http://pypi.python.org/pypi?%3Aaction=list_classifiers
@@ -91,13 +91,12 @@ setup(
         'Intended Audience :: Information Technology',
         'Intended Audience :: Science/Research',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'License :: OSI Approved :: Apache Software License',
         'Topic :: Scientific/Engineering :: Artificial Intelligence',
         'Topic :: Scientific/Engineering :: Bio-Informatics',

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from __future__ import absolute_import
 import io
 import os
 from sys import exit

--- a/test/interval_methods/__init__.py
+++ b/test/interval_methods/__init__.py
@@ -1,5 +1,5 @@
 """
-intervaltree: A mutable, self-balancing interval tree for Python 2 and 3.
+intervaltree: A mutable, self-balancing interval tree for Python.
 Queries may be by point, by range overlap, or by range envelopment.
 
 Test module: Interval methods

--- a/test/interval_methods/binary_test.py
+++ b/test/interval_methods/binary_test.py
@@ -1,5 +1,5 @@
 """
-intervaltree: A mutable, self-balancing interval tree for Python 2 and 3.
+intervaltree: A mutable, self-balancing interval tree for Python.
 Queries may be by point, by range overlap, or by range envelopment.
 
 Test module: Intervals, methods on two intervals

--- a/test/interval_methods/sorting_test.py
+++ b/test/interval_methods/sorting_test.py
@@ -1,5 +1,5 @@
 """
-intervaltree: A mutable, self-balancing interval tree for Python 2 and 3.
+intervaltree: A mutable, self-balancing interval tree for Python.
 Queries may be by point, by range overlap, or by range envelopment.
 
 Test module: Intervals, sorting methods

--- a/test/interval_methods/unary_test.py
+++ b/test/interval_methods/unary_test.py
@@ -1,5 +1,5 @@
 """
-intervaltree: A mutable, self-balancing interval tree for Python 2 and 3.
+intervaltree: A mutable, self-balancing interval tree for Python.
 Queries may be by point, by range overlap, or by range envelopment.
 
 Test module: Intervals, methods on self only

--- a/test/intervals.py
+++ b/test/intervals.py
@@ -18,21 +18,12 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from __future__ import absolute_import
 from intervaltree import Interval
 from pprint import pprint
 from random import randint, choice
 from test.progress_bar import ProgressBar
 import os
-try:
-    xrange
-except NameError:
-    xrange = range
 
-try:
-    unicode
-except NameError:
-    unicode = str
 
 def make_iv(begin, end, label=False):
     if label:
@@ -49,7 +40,7 @@ def nogaps_rand(size=100, labels=False):
     """
     cur = -50
     result = []
-    for i in xrange(size):
+    for i in range(size):
         length = randint(1, 10)
         result.append(make_iv(cur, cur + length, labels))
         cur += length
@@ -65,7 +56,7 @@ def gaps_rand(size=100, labels=False):
     """
     cur = -50
     result = []
-    for i in xrange(size):
+    for i in range(size):
         length = randint(1, 10)
         if choice([True, False]):
             cur += length
@@ -114,7 +105,7 @@ def write_ivs_data(name, ivs, docstring='', imports=None):
         if docstring:
             f.write(trepr(docstring))
             f.write('\n')
-        if isinstance(imports, (str, unicode)):
+        if isinstance(imports, str):
             f.write(imports)
             f.write('\n\n')
         elif isinstance(imports, (list, tuple, set)):

--- a/test/intervals.py
+++ b/test/intervals.py
@@ -1,5 +1,5 @@
 """
-intervaltree: A mutable, self-balancing interval tree for Python 2 and 3.
+intervaltree: A mutable, self-balancing interval tree for Python.
 Queries may be by point, by range overlap, or by range envelopment.
 
 Test module: utilities to generate intervals

--- a/test/intervaltree_methods/__init__.py
+++ b/test/intervaltree_methods/__init__.py
@@ -1,5 +1,5 @@
 """
-intervaltree: A mutable, self-balancing interval tree for Python 2 and 3.
+intervaltree: A mutable, self-balancing interval tree for Python.
 Queries may be by point, by range overlap, or by range envelopment.
 
 Test module: IntervalTree methods

--- a/test/intervaltree_methods/copy_test.py
+++ b/test/intervaltree_methods/copy_test.py
@@ -18,13 +18,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from __future__ import absolute_import
 from intervaltree import Interval, IntervalTree
 from test import data
-try:
-    import cPickle as pickle
-except ImportError:
-    import pickle
+import pickle
 
 
 def test_copy():

--- a/test/intervaltree_methods/copy_test.py
+++ b/test/intervaltree_methods/copy_test.py
@@ -1,5 +1,5 @@
 """
-intervaltree: A mutable, self-balancing interval tree for Python 2 and 3.
+intervaltree: A mutable, self-balancing interval tree for Python.
 Queries may be by point, by range overlap, or by range envelopment.
 
 Test module: IntervalTree, Copying

--- a/test/intervaltree_methods/debug_test.py
+++ b/test/intervaltree_methods/debug_test.py
@@ -18,15 +18,11 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from __future__ import absolute_import
 from intervaltree import Interval, IntervalTree
 import pytest
 from test import data
 from pprint import pprint, pformat
-try:
-    import cPickle as pickle
-except ImportError:
-    import pickle
+import pickle
 
 
 def test_print_empty():

--- a/test/intervaltree_methods/debug_test.py
+++ b/test/intervaltree_methods/debug_test.py
@@ -1,5 +1,5 @@
 """
-intervaltree: A mutable, self-balancing interval tree for Python 2 and 3.
+intervaltree: A mutable, self-balancing interval tree for Python.
 Queries may be by point, by range overlap, or by range envelopment.
 
 Test module: IntervalTree, Basic query methods (read-only)

--- a/test/intervaltree_methods/delete_test.py
+++ b/test/intervaltree_methods/delete_test.py
@@ -18,14 +18,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from __future__ import absolute_import
 from intervaltree import Interval, IntervalTree
 import pytest
 from test import data, match
-try:
-    import cPickle as pickle
-except ImportError:
-    import pickle
+import pickle
 
 
 def test_delete():

--- a/test/intervaltree_methods/delete_test.py
+++ b/test/intervaltree_methods/delete_test.py
@@ -1,5 +1,5 @@
 """
-intervaltree: A mutable, self-balancing interval tree for Python 2 and 3.
+intervaltree: A mutable, self-balancing interval tree for Python.
 Queries may be by point, by range overlap, or by range envelopment.
 
 Test module: IntervalTree, Basic deletion methods

--- a/test/intervaltree_methods/init_test.py
+++ b/test/intervaltree_methods/init_test.py
@@ -18,14 +18,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from __future__ import absolute_import
 from intervaltree import Interval, IntervalTree
 import pytest
-
-try:
-    import cPickle as pickle
-except ImportError:
-    import pickle
+import pickle
 
 
 def test_empty_init():

--- a/test/intervaltree_methods/init_test.py
+++ b/test/intervaltree_methods/init_test.py
@@ -1,5 +1,5 @@
 """
-intervaltree: A mutable, self-balancing interval tree for Python 2 and 3.
+intervaltree: A mutable, self-balancing interval tree for Python.
 Queries may be by point, by range overlap, or by range envelopment.
 
 Test module: IntervalTree, initialization methods

--- a/test/intervaltree_methods/insert_test.py
+++ b/test/intervaltree_methods/insert_test.py
@@ -1,5 +1,5 @@
 """
-intervaltree: A mutable, self-balancing interval tree for Python 2 and 3.
+intervaltree: A mutable, self-balancing interval tree for Python.
 Queries may be by point, by range overlap, or by range envelopment.
 
 Test module: IntervalTree, Basic insertion methods

--- a/test/intervaltree_methods/insert_test.py
+++ b/test/intervaltree_methods/insert_test.py
@@ -18,14 +18,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from __future__ import absolute_import
 from intervaltree import Interval, IntervalTree
 import pytest
 from test import data, match
-try:
-    import cPickle as pickle
-except ImportError:
-    import pickle
+import pickle
 
 
 def test_insert():

--- a/test/intervaltree_methods/query_test.py
+++ b/test/intervaltree_methods/query_test.py
@@ -1,5 +1,5 @@
 """
-intervaltree: A mutable, self-balancing interval tree for Python 2 and 3.
+intervaltree: A mutable, self-balancing interval tree for Python.
 Queries may be by point, by range overlap, or by range envelopment.
 
 Test module: IntervalTree, Basic query methods (read-only)

--- a/test/intervaltree_methods/query_test.py
+++ b/test/intervaltree_methods/query_test.py
@@ -18,14 +18,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from __future__ import absolute_import
 from intervaltree import Interval, IntervalTree
 import pytest
 from test import data, match
-try:
-    import cPickle as pickle
-except ImportError:
-    import pickle
+import pickle
 
 
 def test_empty_queries():

--- a/test/intervaltree_methods/restructure_test.py
+++ b/test/intervaltree_methods/restructure_test.py
@@ -18,14 +18,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from __future__ import absolute_import
 from intervaltree import Interval, IntervalTree
 import pytest
 from test import data
-try:
-    import cPickle as pickle
-except ImportError:
-    import pickle
+import pickle
 
 
 # -----------------------------------------------------------------------------

--- a/test/intervaltree_methods/restructure_test.py
+++ b/test/intervaltree_methods/restructure_test.py
@@ -1,5 +1,5 @@
 """
-intervaltree: A mutable, self-balancing interval tree for Python 2 and 3.
+intervaltree: A mutable, self-balancing interval tree for Python.
 Queries may be by point, by range overlap, or by range envelopment.
 
 Test module: IntervalTree, Special methods

--- a/test/intervaltree_methods/setlike_test.py
+++ b/test/intervaltree_methods/setlike_test.py
@@ -1,5 +1,5 @@
 """
-intervaltree: A mutable, self-balancing interval tree for Python 2 and 3.
+intervaltree: A mutable, self-balancing interval tree for Python.
 Queries may be by point, by range overlap, or by range envelopment.
 
 Test module: IntervalTree, Special methods

--- a/test/intervaltree_methods/setlike_test.py
+++ b/test/intervaltree_methods/setlike_test.py
@@ -18,14 +18,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from __future__ import absolute_import
 from intervaltree import Interval, IntervalTree
 import pytest
 from test import data
-try:
-    import cPickle as pickle
-except ImportError:
-    import pickle
+import pickle
 
 
 def test_update():

--- a/test/intervaltrees.py
+++ b/test/intervaltrees.py
@@ -1,5 +1,5 @@
 """
-intervaltree: A mutable, self-balancing interval tree for Python 2 and 3.
+intervaltree: A mutable, self-balancing interval tree for Python.
 Queries may be by point, by range overlap, or by range envelopment.
 
 Test module: utilities to generate test trees

--- a/test/intervaltrees.py
+++ b/test/intervaltrees.py
@@ -18,15 +18,11 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from __future__ import absolute_import
 from intervaltree import IntervalTree
 from pprint import pprint
 from test import intervals, data
 from test.progress_bar import ProgressBar
-try:
-    xrange
-except NameError:
-    xrange = range
+
 
 def nogaps_rand(size=100, labels=False):
     """

--- a/test/issues/__init__.py
+++ b/test/issues/__init__.py
@@ -1,5 +1,5 @@
 """
-intervaltree: A mutable, self-balancing interval tree for Python 2 and 3.
+intervaltree: A mutable, self-balancing interval tree for Python.
 Queries may be by point, by range overlap, or by range envelopment.
 
 Test module: issues by tracking number

--- a/test/issues/issue25_test.py
+++ b/test/issues/issue25_test.py
@@ -1,5 +1,5 @@
 """
-intervaltree: A mutable, self-balancing interval tree for Python 2 and 3.
+intervaltree: A mutable, self-balancing interval tree for Python.
 Queries may be by point, by range overlap, or by range envelopment.
 
 Test module: IntervalTree, insertion and removal of float intervals

--- a/test/issues/issue25_test.py
+++ b/test/issues/issue25_test.py
@@ -19,7 +19,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from __future__ import absolute_import
 from intervaltree import IntervalTree
 from test import data
 import pytest

--- a/test/issues/issue26_test.py
+++ b/test/issues/issue26_test.py
@@ -1,5 +1,5 @@
 """
-intervaltree: A mutable, self-balancing interval tree for Python 2 and 3.
+intervaltree: A mutable, self-balancing interval tree for Python.
 Queries may be by point, by range overlap, or by range envelopment.
 
 Test module: IntervalTree, insertion and removal of float intervals

--- a/test/issues/issue26_test.py
+++ b/test/issues/issue26_test.py
@@ -20,7 +20,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from __future__ import absolute_import
 from intervaltree import IntervalTree, Interval
 # from test.intervaltrees import trees
 import pytest

--- a/test/issues/issue27_test.py
+++ b/test/issues/issue27_test.py
@@ -1,5 +1,5 @@
 """
-intervaltree: A mutable, self-balancing interval tree for Python 2 and 3.
+intervaltree: A mutable, self-balancing interval tree for Python.
 Queries may be by point, by range overlap, or by range envelopment.
 
 Test module: IntervalTree, insertion and removal of float intervals

--- a/test/issues/issue27_test.py
+++ b/test/issues/issue27_test.py
@@ -20,7 +20,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from __future__ import absolute_import
 from intervaltree import IntervalTree, Interval
 import pytest
 

--- a/test/issues/issue4.py
+++ b/test/issues/issue4.py
@@ -4,7 +4,6 @@ https://github.com/konstantint/PyIntervalTree/issues/4
 
 Test contributed by jacekt
 '''
-from __future__ import absolute_import
 from intervaltree import IntervalTree
 from test.progress_bar import ProgressBar
 from test import data

--- a/test/issues/issue41_test.py
+++ b/test/issues/issue41_test.py
@@ -1,5 +1,5 @@
 """
-intervaltree: A mutable, self-balancing interval tree for Python 2 and 3.
+intervaltree: A mutable, self-balancing interval tree for Python.
 Queries may be by point, by range overlap, or by range envelopment.
 
 Test module: IntervalTree, removal of intervals

--- a/test/issues/issue41_test.py
+++ b/test/issues/issue41_test.py
@@ -19,7 +19,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from __future__ import absolute_import
 from intervaltree import IntervalTree
 from test import data
 import pytest

--- a/test/issues/issue67_test.py
+++ b/test/issues/issue67_test.py
@@ -21,7 +21,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from __future__ import absolute_import
 from intervaltree import IntervalTree
 import pytest
 

--- a/test/issues/issue67_test.py
+++ b/test/issues/issue67_test.py
@@ -1,5 +1,5 @@
 """
-intervaltree: A mutable, self-balancing interval tree for Python 2 and 3.
+intervaltree: A mutable, self-balancing interval tree for Python.
 Queries may be by point, by range overlap, or by range envelopment.
 
 Test module: IntervalTree, insertion of a sequence of intervals caused

--- a/test/issues/issue72_test.py
+++ b/test/issues/issue72_test.py
@@ -21,7 +21,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from __future__ import absolute_import
 from intervaltree import IntervalTree, Interval
 import pytest
 

--- a/test/issues/issue72_test.py
+++ b/test/issues/issue72_test.py
@@ -1,5 +1,5 @@
 """
-intervaltree: A mutable, self-balancing interval tree for Python 2 and 3.
+intervaltree: A mutable, self-balancing interval tree for Python.
 Queries may be by point, by range overlap, or by range envelopment.
 
 Test module: IntervalTree, remove_overlap caused incorrect balancing

--- a/test/match.py
+++ b/test/match.py
@@ -1,5 +1,5 @@
 """
-intervaltree: A mutable, self-balancing interval tree for Python 2 and 3.
+intervaltree: A mutable, self-balancing interval tree for Python.
 Queries may be by point, by range overlap, or by range envelopment.
 
 Test module: IntervalTree, test utilities

--- a/test/match.py
+++ b/test/match.py
@@ -19,7 +19,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from __future__ import absolute_import
 from intervaltree import Interval
 
 def set_data(s):

--- a/test/optimality/__init__.py
+++ b/test/optimality/__init__.py
@@ -1,5 +1,5 @@
 """
-intervaltree: A mutable, self-balancing interval tree for Python 2 and 3.
+intervaltree: A mutable, self-balancing interval tree for Python.
 Queries may be by point, by range overlap, or by range envelopment.
 
 Test module: IntervalTree structure optimality tests

--- a/test/optimality/optimality_test.py
+++ b/test/optimality/optimality_test.py
@@ -18,7 +18,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from __future__ import absolute_import
 from pprint import pprint
 from warnings import warn
 

--- a/test/optimality/optimality_test.py
+++ b/test/optimality/optimality_test.py
@@ -1,5 +1,5 @@
 """
-intervaltree: A mutable, self-balancing interval tree for Python 2 and 3.
+intervaltree: A mutable, self-balancing interval tree for Python.
 Queries may be by point, by range overlap, or by range envelopment.
 
 Test module: IntervalTree optimality

--- a/test/optimality/optimality_test_matrix.py
+++ b/test/optimality/optimality_test_matrix.py
@@ -1,5 +1,5 @@
 """
-intervaltree: A mutable, self-balancing interval tree for Python 2 and 3.
+intervaltree: A mutable, self-balancing interval tree for Python.
 Queries may be by point, by range overlap, or by range envelopment.
 
 Test module: IntervalTree optimality

--- a/test/optimality/optimality_test_matrix.py
+++ b/test/optimality/optimality_test_matrix.py
@@ -18,17 +18,11 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from __future__ import absolute_import
 from intervaltree import IntervalTree, Interval
 from test import data
 from copy import deepcopy
 from pprint import pprint
 from test.progress_bar import ProgressBar
-
-try:
-    xrange
-except NameError:
-    xrange = range
 
 
 class OptimalityTestMatrix(object):

--- a/test/pprint.py
+++ b/test/pprint.py
@@ -51,18 +51,8 @@ import warnings
 ENABLE_PICKLE_DEFAULT = True
 from numbers import Number
 
-try:
-    from cStringIO import StringIO as _StringIO
-except ImportError:
-    try:
-        from StringIO import StringIO as _StringIO
-    except ImportError:
-        from io import StringIO as _StringIO
+from io import StringIO as _StringIO
 
-try:
-    basestring
-except NameError:
-    basestring = str
 
 __all__ = ["pprint","pformat","isreadable","isrecursive","saferepr",
            "PrettyPrinter"]
@@ -440,7 +430,7 @@ def _pickleable(typ, obj):
     Whether we can use __reduce__ to pprint.
     """
     if (issubclass(typ, Number) or
-        issubclass(typ, basestring)
+        issubclass(typ, str)
     ):  return False
     try:
         reduce_data = obj.__reduce__()

--- a/test/progress_bar.py
+++ b/test/progress_bar.py
@@ -1,5 +1,5 @@
 """
-intervaltree: A mutable, self-balancing interval tree for Python 2 and 3.
+intervaltree: A mutable, self-balancing interval tree for Python.
 Queries may be by point, by range overlap, or by range envelopment.
 
 Test module: progress bar

--- a/test/progress_bar.py
+++ b/test/progress_bar.py
@@ -18,16 +18,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from __future__ import print_function
-from __future__ import division
 from time import time
 from functools import partial
 import sys
-
-try:
-    xrange
-except NameError:
-    xrange = range
 
 
 def write(s):
@@ -414,7 +407,7 @@ def _slow_test():
     from time import sleep
     total = 10
     pbar = ProgressBar(total)
-    for i in xrange(total):
+    for i in range(total):
         pbar()
         sleep(0.5)
 
@@ -425,7 +418,7 @@ def _fast_test():
         total,
         fmt=ProgressBar.Formats.stats_only,
     )
-    for i in xrange(total):
+    for i in range(total):
         pbar()
 
 


### PR DESCRIPTION
This PR updates the codebase and the build process to support the currently maintained Python versions, and drops support for unmaintained versions.

The important thing here is dropping 2.7 support. I went with the assumption that you are fine with that, but I am happy to remove the updates related to that if you want to keep supporting 2.7.